### PR TITLE
Resetting Learners + Code Improvements

### DIFF
--- a/inst/mlr3shiny/server/server_Task.R
+++ b/inst/mlr3shiny/server/server_Task.R
@@ -28,6 +28,10 @@ observe({
   }
 })
 
+observeEvent(currenttask$task,{
+  reset_trained_learner_list()
+})
+
 observe({
   toggle(id = "Task_target", condition = (input$Task_backend == "imported training data"))
   toggle(id = "Task_id", condition = (input$Task_backend == "imported training data"))

--- a/inst/mlr3shiny/server/server_TrainFit.R
+++ b/inst/mlr3shiny/server/server_TrainFit.R
@@ -56,7 +56,13 @@ getLrnModel <- function() {
     return("[missing]")
   }
   else {
-    return(str_replace(Wf$Current_Learner$id, "^(.+?)\\.",""))
+    # cutting down model names like "colapply.encode.classif.svm.threshold" to "classif.svm"
+    # by iterating over LearnerMeta$learner_choice and using this model name 
+    for (learner in LearnerMeta$learner_choice) {
+      if (grepl(learner, Wf$Current_Learner$id)) {
+        return(learner)
+      }
+    }
   }
 }
 

--- a/inst/mlr3shiny/server/server_evaluating.R
+++ b/inst/mlr3shiny/server/server_evaluating.R
@@ -82,7 +82,7 @@ get_compare_method_list <- function() {
 
 # get relevant loss functions for current task
 get_loss_function_list <- function(task, learner) {
-  if (!is.null(lesarner)) {
+  if (!is.null(learner)) {
     if (task$task_type == "classif") {
       if (task$properties == "twoclass") {
         ui <- loss_ui_builder(c(twoclass_losses, classif_losses))

--- a/inst/mlr3shiny/server/server_evaluating.R
+++ b/inst/mlr3shiny/server/server_evaluating.R
@@ -15,7 +15,7 @@ output$eval_learner_selection <- renderUI({
 })
 
 output$eval_loss_function_selection <- renderUI({
-  get_loss_function_list()
+  get_loss_function_list(currenttask$task, input$selected_learner)
 })
 
 output$eval_compare_method_selection <- renderUI({
@@ -81,15 +81,15 @@ get_compare_method_list <- function() {
 
 
 # get relevant loss functions for current task
-get_loss_function_list <- function() {
-  if (!is.null(input$selected_learner)) {
-    if (currenttask$task$task_type == "classif") {
-      if (currenttask$task$properties == "twoclass") {
+get_loss_function_list <- function(task, learner) {
+  if (!is.null(lesarner)) {
+    if (task$task_type == "classif") {
+      if (task$properties == "twoclass") {
         ui <- loss_ui_builder(c(twoclass_losses, classif_losses))
       } else {
         ui <- loss_ui_builder(classif_losses)
       }
-    } else if (currenttask$task$task_type == "regr") {
+    } else if (task$task_type == "regr") {
       ui <- loss_ui_builder(regr_losses)
     }
     return(ui)

--- a/inst/mlr3shiny/server/server_predict.R
+++ b/inst/mlr3shiny/server/server_predict.R
@@ -1,7 +1,5 @@
 # reactive values for the predict tab
 Pred <- reactiveValues(Learner = NULL, Learner_Ov = NULL, New_Data = NULL, Pred = NULL)
-# list of trained learners (will be dynamically filled in the training process)
-trained_learner_list <- reactiveValues()
 
 ## Functions
 # learner selection and overview
@@ -422,11 +420,3 @@ get_final_training_code <- function(task, learner) {
   return(final_train_code)
 }
 
-reset_trained_learner_list <- function () {
-  # iterating over all trained learners and resetting them
-  # See: https://stackoverflow.com/questions/61887112/how-to-reset-reactivevalues
-  for (trained_learner in names(trained_learner_list)) {
-    trained_learner_list[[trained_learner]] <- NULL
-  }
-  print(trained_learner_list)
-}

--- a/inst/mlr3shiny/server/server_predict.R
+++ b/inst/mlr3shiny/server/server_predict.R
@@ -277,8 +277,7 @@ output$Pred_prediction_download_rds <- downloadHandler(
 resetPredLrn <- function() {
   Pred$Learner <- NULL
   Pred$Learner_Ov <- NULL
-  trained_learner_list <- NULL
-  trained_learner_list <- reactiveValues()
+  reset_trained_learner_list()
 }
 
 
@@ -421,4 +420,13 @@ get_final_training_code <- function(task, learner) {
   final_train_code <- paste0(final_train_code, "learner$predict(task) <br>")
   }
   return(final_train_code)
+}
+
+reset_trained_learner_list <- function () {
+  # iterating over all trained learners and resetting them
+  # See: https://stackoverflow.com/questions/61887112/how-to-reset-reactivevalues
+  for (trained_learner in names(trained_learner_list)) {
+    trained_learner_list[[trained_learner]] <- NULL
+  }
+  print(trained_learner_list)
 }


### PR DESCRIPTION
This pull request contains the following functionalities:
### Resetting the list of already trained learners (noted by @g-rho )
Two new methods have been added:

- `reset_trained_learner_list` which is called on a task change
- `reset_single_trained_learner` which is called when the learner type is changed  or parameters are changed

### fixing implicit function calls 
`get_loss_function_list` now uses parameters instead of implicitly accessing variables 

### displaying model name correctly
In `server_TrainFit.R` the regex is now removed and replaced with a basic for loop.
Using this approach long model names like `colapply.encode.classif.svm.threshold`can be cut down to the necessary `classif.svm`
