### PR TITLE
Issue #9 (__BenchmarkResult__data' is deprecated) fixed

### DIFF
--- a/inst/mlr3shiny/server/server_benchmarking.R
+++ b/inst/mlr3shiny/server/server_benchmarking.R
@@ -55,7 +55,7 @@ getItersOv <- function() {
     return("[not available]")
   }
   else {
-    return(paste((Bench$Bench_Rslt$data$iterations()), "iterations in", nrow(Bench$Bench_Rslt$data$resamplings()),"resamplings", sep = " "))
+    return(paste(max(as.data.table(Bench$Bench_Rslt)$iteration), "iterations for", table(as.data.table(Bench$Bench_Rslt)$iteration)[1],"learners", sep = " "))
   }
 }
 


### PR DESCRIPTION
...in  in server_benchmarking.R (ln.58).
In addition printed output changed in #iterations per #learners.