### PR TITLE
code generation fixed / parameter specific stepsizes in UI / .md updated / issue #28 and #29 solved

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Current functionalities of mlr3shiny are:
 * Training and evaluation of the generated models
 * Benchmarking to compare several learners on a task simultaneously
 * Prediction on new data using the trained learner
+* Explain trained learner 
 
 ## Installation
 
@@ -38,9 +39,11 @@ Start by importing a dataset. Then define a task (the problem to be solved) in t
 Resampling strategies can be applied in a sub-section of 'train & evaluate'.
 Alternatively, different learners can be compared in a benchmark.
 Use the final model to make a prediction on new data in the 'predict' tab. 
+An explanation of the final model from the predict tab can be made in the 'explain' tab. 
 
 ## References to Algorithms
 * [linear/ logistic regression](https://stat.ethz.ch/R-manual/R-devel/library/stats/html/00Index.html)
 * [decision tree](https://CRAN.R-project.org/package=rpart)
 * [random forest](https://CRAN.R-project.org/package=ranger)
 * [support vector machine](https://CRAN.R-project.org/package=e1071)
+* [xgboost](https://CRAN.R-project.org/package=xgboost)

--- a/inst/mlr3shiny/server/server_Learner.R
+++ b/inst/mlr3shiny/server/server_Learner.R
@@ -184,7 +184,7 @@ makeOverviewUi <- function(learnerobject) {
 }
 
 ## Learner params
-addNumericParam <- function(id, lower, upper, learnername, default) {
+addNumericParam <- function(id, lower, upper, learnername, default, stpsize = 1) {
    fluidRow(
       column(3,
              h5(id)
@@ -197,7 +197,7 @@ addNumericParam <- function(id, lower, upper, learnername, default) {
       ),
       column(3,
              numericInput(inputId = paste0(learnername, "Param", id), label = NULL,
-                          value = default, min = lower, max = upper)
+                          value = default, min = lower, max = upper, step = stpsize)
       )
 
    )
@@ -232,7 +232,8 @@ getKernelParams <- function(learnerobject, learnername, selectedkernel) {
       kernelparams <- tagList(
          addNumericParam(id = paste0(learnerobject$Learner_Name,".","gamma"), lower = learnerobject$Learner$param_set$params[[paste0(learnerobject$Learner_Name,".","gamma")]]$lower,
                          upper = learnerobject$Learner$param_set$params[[paste0(learnerobject$Learner_Name,".","gamma")]]$upper,
-                         learnername = learnername, default = learnerobject$Learner$param_set$params[[paste0(learnerobject$Learner_Name,".","gamma")]]$default),
+                         learnername = learnername, default = learnerobject$Learner$param_set$params[[paste0(learnerobject$Learner_Name,".","gamma")]]$default,
+                         stpsize = 0.1),
          addNumericParam(id = paste0(learnerobject$Learner_Name,".","degree"), lower = learnerobject$Learner$param_set$params[[paste0(learnerobject$Learner_Name,".","degree")]]$lower,
                          upper = learnerobject$Learner$param_set$params[[paste0(learnerobject$Learner_Name,".","degree")]]$upper,
                          learnername = learnername, default = learnerobject$Learner$param_set$params[[paste0(learnerobject$Learner_Name,".","degree")]]$default)
@@ -247,7 +248,8 @@ getKernelParams <- function(learnerobject, learnername, selectedkernel) {
    else if (selectedkernel == "radial" || selectedkernel == "sigmoid") {
       kernelparams <- tagList(
          addNumericParam(id = paste0(learnerobject$Learner_Name,".","gamma"), lower = learnerobject$Learner$param_set$params[[paste0(learnerobject$Learner_Name,".","gamma")]]$lower, upper = learnerobject$Learner$param_set$params[[paste0(learnerobject$Learner_Name,".","gamma")]]$upper,
-                        learnername = learnername, default = learnerobject$Learner$param_set$params[[paste0(learnerobject$Learner_Name,".","gamma")]]$default)
+                        learnername = learnername, default = learnerobject$Learner$param_set$params[[paste0(learnerobject$Learner_Name,".","gamma")]]$default,
+                        stpsize = 0.1)
       )
       learnerobject$Params <- c(learnerobject$Learner$param_set$params[[paste0(learnerobject$Learner_Name,".","kernel")]],
                                  learnerobject$Learner$param_set$params[[paste0(learnerobject$Learner_Name,".","cost")]],
@@ -304,7 +306,7 @@ makeParamUi <- function(learnerobject, learnername) {
          #min.node.size
          addNumericParam(id = params[[3]]$id, lower = params[[3]]$lower, upper = params[[3]]$upper, learnername = learnername,
                        default = params[[3]]$default),
-         addNumericParam(id = params[[length(params)]]$id, lower = 0, upper = 1, learnername = learnername, default = 0.5),
+         addNumericParam(id = params[[length(params)]]$id, lower = 0, upper = 1, learnername = learnername, default = 0.5, stpsize = 0.1),
          actionButton(inputId = paste0(learnername, "ChangeParams"), label = "Change Parameters", style = "float: right;")
       )
       } else {
@@ -327,22 +329,22 @@ makeParamUi <- function(learnerobject, learnername) {
       if (grepl("threshold", learnerobject$Learner$id)) {
          parameterui <- tagList(
          addNumericParam(id = params[[1]]$id, lower = params[[1]]$lower, upper = params[[1]]$upper, learnername = learnername,
-                         default = params[[1]]$default),
+                         default = params[[1]]$default, stpsize = 1),
          addNumericParam(id = params[[2]]$id, lower = params[[2]]$lower, upper = params[[2]]$upper, learnername = learnername,
-                         default = params[[2]]$default),
+                         default = params[[2]]$default, stpsize = 0.0025),
          addNumericParam(id = params[[3]]$id, lower = params[[3]]$lower, upper = params[[3]]$upper, learnername = learnername,
-                         default = params[[3]]$default),
-         addNumericParam(id = params[[length(params)]]$id, lower = 0, upper = 1, learnername = learnername, default = 0.5),
+                         default = params[[3]]$default, stpsize = 1),
+         addNumericParam(id = params[[length(params)]]$id, lower = 0, upper = 1, learnername = learnername, default = 0.5, paramtype = params[[length(params)]]$class),
          actionButton(inputId = paste0(learnername, "ChangeParams"), label = "Change Parameters", style = "float: right;")
       )
       } else {
          parameterui <- tagList(
          addNumericParam(id = params[[1]]$id, lower = params[[1]]$lower, upper = params[[1]]$upper, learnername = learnername,
-                         default = params[[1]]$default),
+                         default = params[[1]]$default, stpsize = 1),
          addNumericParam(id = params[[2]]$id, lower = params[[2]]$lower, upper = params[[2]]$upper, learnername = learnername,
-                         default = params[[2]]$default),
+                         default = params[[2]]$default, stpsize = 0.0025),
          addNumericParam(id = params[[3]]$id, lower = params[[3]]$lower, upper = params[[3]]$upper, learnername = learnername,
-                         default = params[[3]]$default),
+                         default = params[[3]]$default, stpsize = 1),
          actionButton(inputId = paste0(learnername, "ChangeParams"), label = "Change Parameters", style = "float: right;")
       )
       }
@@ -354,9 +356,9 @@ makeParamUi <- function(learnerobject, learnername) {
          # sigmoid kernel removed for explanatory reasons
          addFactorParam(id = params[[1]]$id, levels = c("radial", "polynomial", "linear"), learnername = learnername, default = params[[1]]$default),
          addNumericParam(id = params[[2]]$id, lower = params[[2]]$lower, upper = params[[2]]$upper, learnername = learnername,
-                         default = params[[2]]$default),
+                         default = params[[2]]$default, stpsize = 0.1),
          uiOutput(outputId = paste0(learnername, "KernelParam", "kernel")), # depending on selected kernel, different hyperparameters are available
-         addNumericParam(id = params[[length(params)]]$id, lower = 0, upper = 1, learnername = learnername, default = 0.5),
+         addNumericParam(id = params[[length(params)]]$id, lower = 0, upper = 1, learnername = learnername, default = 0.5, stpsize = 0.1),
          actionButton(inputId = paste0(learnername, "ChangeParams"), label = "Change Parameters", style = "float: right;")
       )
       } else {
@@ -364,7 +366,7 @@ makeParamUi <- function(learnerobject, learnername) {
       # sigmoid kernel removed for explanatory reasons
       addFactorParam(id = params[[1]]$id, levels = c("radial", "polynomial", "linear"), learnername = learnername, default = params[[1]]$default),
       addNumericParam(id = params[[2]]$id, lower = params[[2]]$lower, upper = params[[2]]$upper, learnername = learnername,
-                      default = params[[2]]$default),
+                      default = params[[2]]$default, stpsize = 0.1),
       uiOutput(outputId = paste0(learnername, "KernelParam", "kernel")), # depending on selected kernel, different hyperparameters are available
       actionButton(inputId = paste0(learnername, "ChangeParams"), label = "Change Parameters", style = "float: right;")
       )
@@ -374,20 +376,20 @@ makeParamUi <- function(learnerobject, learnername) {
       params <- getAvailableParams(algorithm = "xgboost", learnerobject = learnerobject)
       if (grepl("threshold", learnerobject$Learner$id)) {
       parameterui <- tagList(
-         addNumericParam(id = params[[1]]$id, lower = params[[1]]$lower, upper = params[[1]]$upper, learnername = learnername, default = params[[1]]$default),
-         addNumericParam(id = params[[2]]$id, lower = params[[2]]$lower, upper = params[[2]]$upper, learnername = learnername, default = params[[2]]$default),
-         addNumericParam(id = params[[3]]$id, lower = params[[3]]$lower, upper = params[[3]]$upper, learnername = learnername, default = params[[3]]$default),
-         addNumericParam(id = params[[4]]$id, lower = params[[4]]$lower, upper = params[[4]]$upper, learnername = learnername, default = params[[4]]$default),
+         addNumericParam(id = params[[1]]$id, lower = params[[1]]$lower, upper = params[[1]]$upper, learnername = learnername, default = params[[1]]$default, stpsize = 0.1),
+         addNumericParam(id = params[[2]]$id, lower = params[[2]]$lower, upper = params[[2]]$upper, learnername = learnername, default = params[[2]]$default, stpsize = 1),
+         addNumericParam(id = params[[3]]$id, lower = params[[3]]$lower, upper = params[[3]]$upper, learnername = learnername, default = params[[3]]$default, stpsize = 1),
+         addNumericParam(id = params[[4]]$id, lower = params[[4]]$lower, upper = params[[4]]$upper, learnername = learnername, default = params[[4]]$default, stpsize = 0.1),
          addFactorParam(id = params[[5]]$id, levels = c("gblinear", "gbtree","dart"), learnername = learnername, default = params[[5]]$default),
-         addNumericParam(id = params[[length(params)]]$id, lower = 0, upper = 1, learnername = learnername, default = 0.5),
+         addNumericParam(id = params[[length(params)]]$id, lower = 0, upper = 1, learnername = learnername, default = 0.5, stpsize = 0.1),
          actionButton(inputId = paste0(learnername, "ChangeParams"), label = "Change Parameters", style = "float: right;")
       )
       } else {
       parameterui <- tagList(
-         addNumericParam(id = params[[1]]$id, lower = params[[1]]$lower, upper = params[[1]]$upper, learnername = learnername, default = params[[1]]$default),
-         addNumericParam(id = params[[2]]$id, lower = params[[2]]$lower, upper = params[[2]]$upper, learnername = learnername, default = params[[2]]$default),
-         addNumericParam(id = params[[3]]$id, lower = params[[3]]$lower, upper = params[[3]]$upper, learnername = learnername, default = params[[3]]$default),
-         addNumericParam(id = params[[4]]$id, lower = params[[4]]$lower, upper = params[[4]]$upper, learnername = learnername, default = params[[4]]$default),
+         addNumericParam(id = params[[1]]$id, lower = params[[1]]$lower, upper = params[[1]]$upper, learnername = learnername, default = params[[1]]$default, stpsize = 0.1),
+         addNumericParam(id = params[[2]]$id, lower = params[[2]]$lower, upper = params[[2]]$upper, learnername = learnername, default = params[[2]]$default, stpsize = 1),
+         addNumericParam(id = params[[3]]$id, lower = params[[3]]$lower, upper = params[[3]]$upper, learnername = learnername, default = params[[3]]$default, stpsize = 1),
+         addNumericParam(id = params[[4]]$id, lower = params[[4]]$lower, upper = params[[4]]$upper, learnername = learnername, default = params[[4]]$default, stpsize = 0.1),
          addFactorParam(id = params[[5]]$id, levels = c("gblinear", "gbtree","dart"), learnername = learnername, default = params[[5]]$default),
          actionButton(inputId = paste0(learnername, "ChangeParams"), label = "Change Parameters", style = "float: right;")
       )

--- a/inst/mlr3shiny/server/server_Learner.R
+++ b/inst/mlr3shiny/server/server_Learner.R
@@ -334,7 +334,7 @@ makeParamUi <- function(learnerobject, learnername) {
                          default = params[[2]]$default, stpsize = 0.0025),
          addNumericParam(id = params[[3]]$id, lower = params[[3]]$lower, upper = params[[3]]$upper, learnername = learnername,
                          default = params[[3]]$default, stpsize = 1),
-         addNumericParam(id = params[[length(params)]]$id, lower = 0, upper = 1, learnername = learnername, default = 0.5, paramtype = params[[length(params)]]$class),
+         addNumericParam(id = params[[length(params)]]$id, lower = 0, upper = 1, learnername = learnername, default = 0.5, stpsize = 0.1),
          actionButton(inputId = paste0(learnername, "ChangeParams"), label = "Change Parameters", style = "float: right;")
       )
       } else {

--- a/inst/mlr3shiny/server/server_Resample.R
+++ b/inst/mlr3shiny/server/server_Resample.R
@@ -68,7 +68,7 @@ stratify <- function(id, default) {
 ratio <- function(id, default) {
   ratioui <- tagList(
     column(6,
-           numericInput(inputId = paste0(id, "_ratio"), label = h5("Fraction in (0, 1) of the data used for training the model"), value = default, min = 0, max = 1)
+           numericInput(inputId = paste0(id, "_ratio"), label = h5("Fraction in (0, 1) of the data used for training the model"), value = default, min = 0, max = 1, step = 0.1)
            )
   )
   return(ratioui)

--- a/inst/mlr3shiny/server/server_predict.R
+++ b/inst/mlr3shiny/server/server_predict.R
@@ -172,17 +172,17 @@ observeEvent(input$Pred_codegen, {
   showModal(
     modalDialog(
       title = h2("Code Generation", style = "text-align: center;"),
-      h4("Task Creation"),
+      h4("## Task Creation"),
       HTML(get_task_code(currenttask$task)),
-      h4("Learner Creation"),
+      h4("## Learner Creation"),
       HTML(get_learner_code(Pred$Learner)),
-      h4("Training"),
+      h4("## Training"),
       HTML(get_training_code()),
-      h4("Scoring"),
+      h4("## Scoring"),
       HTML(get_score_code(currenttask$task, Pred$Learner)),
-      h4("Resampling"),
+      h4("## Resampling"),
       HTML(get_resampling_code()),
-      h4("Final Training and Predict"),
+      h4("## Final Training and Predict"),
       HTML(get_final_training_code(currenttask$task, Pred$Learner)),
       easyClose = TRUE,
       footer = div(style = "display:inline-block;width:100%;text-align: center;",
@@ -329,13 +329,19 @@ get_task_code <- function(task) {
 }
 
 get_learner_code <- function(learner) {
+print(learner$param_set)
   # creating intial graph
   learner_code <- "# create initial graph <br>"
   learner_code <- paste0(learner_code, "graph <- Graph$new() <br>")
   # adding graph learner to graph
   learner_name <- learner$graph$ids()[grep("\\.", learner$graph$ids())]
   learner_code <- paste0(learner_code, "# adding learner PipeOp <br>")
-  learner_code <- paste0(learner_code, "graph$add_pipeop(lrn(\"", learner_name, "\", predict_type = \"", learner$predict_type, "\")) <br>")
+  if(!isTRUE(currenttask$task$properties == "twoclass")){
+    learner_code <- paste0(learner_code, "graph$add_pipeop(lrn(\"", learner_name, "\", predict_type = \"", learner$predict_type, "\")) <br>")
+    }
+  if(isTRUE(currenttask$task$properties == "twoclass")){
+    learner_code <- paste0(learner_code, "graph$add_pipeop(lrn(\"", learner_name, "\", predict_type = \"prob\")) <br>")
+  }
   if (any(grepl("encode", learner$graph$ids()))) {
     learner_code <- paste0(learner_code,
     "# adding a PipeOp to enable the usage of factor columns for the chosen learner <br>")
@@ -349,7 +355,7 @@ get_learner_code <- function(learner) {
   }
   if(isTRUE(currenttask$task$properties == "twoclass")){
     learner_code <- paste0(learner_code, "# adding a threshold PipeOp for twoclass task <br>")
-    learner_code <- paste0(learner_code, "graph <- po(\"threshold\") %>>% graph <br>")
+    learner_code <- paste0(learner_code, "graph <- graph %>>% po(\"threshold\") <br>")
   }
   for (parameter in names(learner$param_set$values)) {
     learner_code <- paste0(learner_code, "graph$param_set$values$", parameter, "<- ", learner$param_set$values[parameter], "<br>")


### PR DESCRIPTION
- Erroneous code for twoclass classification fixed (po order changed and learner type must be 'prob' ind server_predict.R)
- Prefix '##' added for headlines in code for easier copy and paste into RStudio.
- Parameter specific step sizes in server_learner (additional argument stpsize in addNumericParam() and subsequent calls)  
- Readme.md updated
