### PR TITLE
Added row ID and subsampling option for autoplot and fixed bugs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mlr3shiny
 Title: Machine Learning in 'shiny' with 'mlr3'
-Version: 0.5.6
+Version: 0.5.7
 
 Authors@R: 
     c(person(given = "Laurens",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,14 @@
+# mlr3shiny 0.5.7
+* Adjusted  the available Predict Types for regression tasks
+* Fixed a bug that caused Shiny to crash after switching the SVM kernel
+* Added a subset option to the autoplot in Task
+* Added Shiny version to the title
+* Added error modal when the GraphLearner cannot be plotted
+* Improved the error modal shown when predicting without a trained learner
+* Added the option to select a row-ID
+* Changed the default label of a learner
+* Fixed outdated code that caused a crash in Explain
+
 # mlr3shiny 0.5.6
 
 * Fixed options in ordered_action within the Robustify pipeline

--- a/inst/mlr3shiny/global.R
+++ b/inst/mlr3shiny/global.R
@@ -349,7 +349,7 @@ errorAlertPredictNew <- function(error) {
   errorModal(title = "Predicting Target Failed",
              description = paste("Sorry, predicting the target variable of the newly imported dataset did not work.",
                                  "Please have a look at the error message to get insight into the cause.", sep = " "),
-             err = error$message,
+             err = "Prediction is not possible because the learner has not been trained yet. Please train the learner again on all data in the Predict tab.",
              id = "okPredict")
 }
 
@@ -394,3 +394,20 @@ warningAlert <- function(warning) {
 messageDetail <- function(msg) {
   showNotification(msg, type = "message")
 }
+
+get_version <- function() {
+  version <- read.dcf("../../DESCRIPTION", fields = "Version")
+  return (version[1,1])
+}
+
+errorInvalidGraphicsState <- function(error) {
+  errorModal(title = "Invalid Graphics State",
+             description = paste("The GraphLearner could not be plotted in RStudio 
+                                 because there is not enough space on the screen. 
+                                 Please expand the sidebar to display the visualization.",
+                                 sep = " "),
+             err = error$message,
+             id = "okLearner")
+
+}
+

--- a/inst/mlr3shiny/server/server_explain.R
+++ b/inst/mlr3shiny/server/server_explain.R
@@ -65,7 +65,7 @@ observeEvent(input$evaluate_start, {
         if (isTRUE(currenttask$task$properties == "twoclass") ){
           
           #Preparation for Explainer | TASK
-          dalex_temp <- currenttask$task$data(data_format = "data.table")
+          dalex_temp <- currenttask$task$data() 
           dalex_predictors <- dalex_temp %>% select(-currenttask$task$target_names)
           dalex_target <- dalex_temp %>% select(currenttask$task$target_names)
           colnames(dalex_target) <- "target"

--- a/inst/mlr3shiny/server/server_learner.R
+++ b/inst/mlr3shiny/server/server_learner.R
@@ -1,12 +1,12 @@
 # each Learner has its own reactive values
 LearnerMeta <- reactiveValues(Count = 1, learner_choice = NULL, Learner_Avail = NULL, TwoClass = NULL)
-Learner1 <- reactiveValues(Learner = NULL, Overview = NULL, Params = list(), Predict_Type = NULL, Hash = NULL, Learner_Name = NULL)
-Learner2 <- reactiveValues(Learner = NULL, Overview = NULL, Params = list(), Predict_Type = NULL, Hash = NULL, Learner_Name = NULL)
-Learner3 <- reactiveValues(Learner = NULL, Overview = NULL, Params = list(), Predict_Type = NULL, Hash = NULL, Learner_Name = NULL)
-Learner4 <- reactiveValues(Learner = NULL, Overview = NULL, Params = list(), Predict_Type = NULL, Hash = NULL, Learner_Name = NULL)
-Learner5 <- reactiveValues(Learner = NULL, Overview = NULL, Params = list(), Predict_Type = NULL, Hash = NULL, Learner_Name = NULL)
-Learner6 <- reactiveValues(Learner = NULL, Overview = NULL, Params = list(), Predict_Type = NULL, Hash = NULL, Learner_Name = NULL)
-Learner7 <- reactiveValues(Learner = NULL, Overview = NULL, Params = list(), Predict_Type = NULL, Hash = NULL, Learner_Name = NULL)
+Learner1 <- reactiveValues(Learner = NULL, Overview = NULL, Params = list(), Predict_Type = NULL, Hash = NULL, Learner_Name = NULL, Index = 1) 
+Learner2 <- reactiveValues(Learner = NULL, Overview = NULL, Params = list(), Predict_Type = NULL, Hash = NULL, Learner_Name = NULL, Index = 2)
+Learner3 <- reactiveValues(Learner = NULL, Overview = NULL, Params = list(), Predict_Type = NULL, Hash = NULL, Learner_Name = NULL, Index = 3)
+Learner4 <- reactiveValues(Learner = NULL, Overview = NULL, Params = list(), Predict_Type = NULL, Hash = NULL, Learner_Name = NULL, Index = 4)
+Learner5 <- reactiveValues(Learner = NULL, Overview = NULL, Params = list(), Predict_Type = NULL, Hash = NULL, Learner_Name = NULL, Index = 5)
+Learner6 <- reactiveValues(Learner = NULL, Overview = NULL, Params = list(), Predict_Type = NULL, Hash = NULL, Learner_Name = NULL, Index = 6)
+Learner7 <- reactiveValues(Learner = NULL, Overview = NULL, Params = list(), Predict_Type = NULL, Hash = NULL, Learner_Name = NULL, Index = 7)
 
 # list of trained learners (will be dynamically filled in the training process)
 trained_learner_list <- reactiveValues()
@@ -202,7 +202,7 @@ makeOverviewUi <- function(learnerobject) {
             addOverviewLineLearner("Current Predict Type: ", custom_map(learnerobject$Overview[[2]])),
             # addOverviewLineLearner("Current Parameter: ", paste(learnerobject$Overview[[3]], collapse = ", "))
             # A bug in the next line: Es wird nicht angezeigt (weil auflistung)
-            addOverviewLineLearner("Supported Predict Types: ", paste(custom_map(learnerobject$Overview[[3]]), collapse = ", ")),
+            addOverviewLineLearner("Supported Predict Types: ", paste(custom_map(learnerobject$Learner$graph$pipeops[[3]]$learner$predict_types), collapse = ", ")),
             textInput(inputId = paste0(learnerobject$Learner_Name, "LabelChoice"), label = "Label:", value = "", width = NULL, placeholder = "Create Learner label"),
             actionButton(inputId = paste0(learnerobject$Learner_Name, "LabelChange"), label = "Change Label", style = "float: left;")
             ),
@@ -544,7 +544,7 @@ makeLearnerParamTab <- function(learnerobject, learnername) {
             column(
                4,
                selectInput(
-                  inputId = paste0(learnername, "PredictTypeChoice"), label = NULL, choices = setNames(learnerobject$Learner$predict_types, custom_map(learnerobject$Learner$predict_types)),
+                  inputId = paste0(learnername, "PredictTypeChoice"), label = NULL, choices = setNames(learnerobject$Learner$graph$pipeops[[3]]$learner$predict_types, custom_map(learnerobject$Learner$graph$pipeops[[3]]$learner$predict_types)),
                   selected = learnerobject$Learner$predict_type
                )
             ),
@@ -629,7 +629,10 @@ createGraphLearner <- function(selectedlearner) {
                                  character_action   = input[["character_action"]],
                                  POSIXct_action     = input[["POSIXct_action"]]) %>>% learner
        
-    plot(graph)
+    tryCatch({plot(graph)}, 
+      error = errorInvalidGraphicsState
+    )
+
   } else graph <- as_graph(po("learner", learner))
   if (isTRUE(currenttask$task$properties == "twoclass")) graph <- graph %>>% po("threshold")
   return(as_learner(graph))
@@ -638,13 +641,15 @@ createGraphLearner <- function(selectedlearner) {
 
 # add observers and others to generate the tabs depending on the needs of the user
 makeLearner <- function(learnerobject, learnername, trigger, selectedlearner, learnerparamoutput, learnerovoutput) {
+   
    observeEvent(input[[trigger]], {
        learnerobject$Learner <- createGraphLearner(selectedlearner)
-      learnerobject$Learner_Name <- input[[selectedlearner]]
-      # learnerobject$Learner <- mlr_learners$get(input[[selectedlearner]])
-      LearnerMeta$Learner_Avail <- unique(sort(c(LearnerMeta$Learner_Avail, learnername)))
-      learnerobject$Hash <- learnerobject$Learner$hash
-      
+       learnerobject$Learner_Name <- input[[selectedlearner]]
+       # learnerobject$Learner <- mlr_learners$get(input[[selectedlearner]])
+       LearnerMeta$Learner_Avail <- unique(sort(c(LearnerMeta$Learner_Avail, learnername)))
+       learnerobject$Hash <- learnerobject$Learner$hash
+       learnerobject$Learner$label <- paste("Learner", learnerobject$Index) 
+
       output[[learnerparamoutput]] <- renderUI({
          makeLearnerParamTab(learnerobject = learnerobject, learnername = learnername)
       })
@@ -689,6 +694,12 @@ makeLearner <- function(learnerobject, learnername, trigger, selectedlearner, le
 
    # # To-Do: get a prettier solution
    observeEvent(input[[paste0(learnername, "ChangeParams")]], {
+     
+     if (grepl("svm", learnerobject$Learner_Name)) {
+       values <- startsWith(names(learnerobject$Learner$param_set$values), "classif") | startsWith(names(learnerobject$Learner$param_set$values), "regr")
+       learnerobject$Learner$param_set$values[values] <- NULL
+     }
+     
       paramlist <- list()
       invalidparams <- NULL
       

--- a/inst/mlr3shiny/server/server_predict.R
+++ b/inst/mlr3shiny/server/server_predict.R
@@ -107,10 +107,20 @@ getNewDataTbl <- function() {
 }
 
 getNewPrediction <- function() {
-  if (!is.null(Pred$Pred)) {
-    tabl <- DT::datatable(as.data.table(Pred$Pred),
-                          options = list(scrollX = TRUE,searching = FALSE, bInfo = FALSE, lengthChange = FALSE, scrollY = "150px"))
-    return(tabl)
+  if (input$Predict_data_rowID && currenttask$rowID != ""){
+    if (!is.null(Pred$Pred)) {
+      tabl <- as.data.table(Pred$Pred)
+      tabl$row_ids <- currenttask$task$data(rows = Pred$Pred$row_ids, cols = currenttask$rowID)[[1]]
+      tabl <- DT::datatable(tabl,
+                            options = list(scrollX = TRUE, searching = FALSE, bInfo = FALSE, lengthChange = FALSE))
+      return(tabl)
+    }
+  } else {
+    if (!is.null(Pred$Pred)) {
+      tabl <- DT::datatable(as.data.table(Pred$Pred),
+                            options = list(scrollX = TRUE, searching = FALSE, bInfo = FALSE, lengthChange = FALSE))
+      return(tabl)
+    }
   }
 }
 
@@ -186,8 +196,15 @@ observeEvent(input$Pred_train_learner, {
     })
 
   Pred$Learner_Ov <- createPredLrnOv()
+  
+  if (currenttask$rowID != "") {
+    updateCheckboxInput(session, inputId = "Predict_data_rowID", label = paste("Use ", currenttask$rowID, "as rowID"))
+    shinyjs::enable("Predict_data_rowID")
+  } else {
+    updateCheckboxInput(session, inputId = "Predict_data_rowID", label = HTML("<div style='color: #808080;'>Use rowID (not available)</div>"), value = FALSE)
+    shinyjs::disable("Predict_data_rowID")
+  }
 })
-
 
 observeEvent(input$Show_info, {
 
@@ -347,8 +364,8 @@ output$Pred_new_data_view <- DT::renderDataTable({
 observeEvent(input$Predict_predict, {
   if (is.null(Pred$Learner) || is.null(Pred$New_Data)) {
     shinyalert(title = "Predicting Failed",
-               text = paste("Please train a learner on the entire training data set and import a new dataset prior to predicting.",
-                            "the target value", sep = " "),
+               text = paste("Please train a learner on the entire training data set and import a new dataset prior to predicting",
+                            "the target value.", sep = " "),
                closeOnClickOutside = TRUE,
                animation = FALSE,
                className="alert-warning",
@@ -376,7 +393,13 @@ output$Pred_prediction_download_csv <- downloadHandler(
     paste("Prediction_new_data", ".csv", sep = "")
   },
   content = function(file) {
-    write.csv(x = as.data.table(Pred$Pred), file = file)
+    if(input$Predict_data_rowID && currenttask$rowID != "") {
+      pred_table <- as.data.table(Pred$Pred)
+      pred_table$row_ids <- currenttask$task$data(rows = Pred$Pred$row_ids, cols = currenttask$rowID)[[1]]
+      write.csv(x = pred_table, file = file)
+    } else {
+      write.csv(x = as.data.table(Pred$Pred), file = file)
+    }
   }
 )
 output$Pred_prediction_download_rds <- downloadHandler(
@@ -629,7 +652,7 @@ observe({
   condition = !is.null(input$Pred_learner)
     && ((Pred$Learner$graph_model$output$op.id %in% c("classif.rpart", "regr.rpart")) 
     | !is.null(Pred$Learner$graph_model$pipeops$classif.rpart)))
-    #last part of condition is needet for twoclass classifcations
+    #last part of condition is needed for twoclass classifcations
 })
 
 raise_alert <- function(message, bttn_confirm=FALSE) {

--- a/inst/mlr3shiny/server/server_task.R
+++ b/inst/mlr3shiny/server/server_task.R
@@ -1,5 +1,5 @@
 # reactive values for task
-currenttask <- reactiveValues(task = NULL, overview = NULL, target = NULL, featNames = NULL, featTypes = NULL, positive = NULL, tableOptions = NULL)
+currenttask <- reactiveValues(task = NULL, overview = NULL, target = NULL, featNames = NULL, featTypes = NULL, positive = NULL, tableOptions = NULL, rowID = NULL) 
 # in case a feature gets dropped make sure to only include the same features when predicting new data
 features_to_use <- reactiveValues(features = NULL)
 # used for visualization puropses
@@ -9,6 +9,38 @@ originalTask <- NULL
 observe({
   if (input$Task_backend == "iris" || input$Task_backend == "mtcars" || input$Task_backend == "german_credit") {
     currenttask$task <- mlr_tasks$get(input$Task_backend)
+    
+    choices <- colnames(currenttask$task$data())
+    choices_reduced <- c()
+    
+    for (i in choices) {
+      if (!is.numeric(currenttask$task$data()[[i]]) && anyDuplicated(currenttask$task$data()[[i]]) == 0 && !any(is.na(currenttask$task$data()[[i]])) && !(currenttask$task$target_names %in% i)) {
+        choices_reduced <- c(choices_reduced, i)
+      }
+    }
+    
+    output$Task_make_rowid <- renderUI({
+      selectInput(
+        inputId = "Task_rowid",
+        label = tags$div(
+          style = "display: flex; align-items: center;",
+          h5("Row ID"),
+          tags$div(
+            title = "To remove the selected Row ID, please press the Backspace key.\nVariables that are internally defined as observation identifiers are excluded from model training.",
+            bs_icon("info-circle"),
+            style = "margin-left: 5px;"
+          )
+        ),
+        choices = c("No rowID" = "", currenttask$task$col_roles$name, choices_reduced),
+        selected = currenttask$rowID
+      )
+    })
+     if (!is.null(input$Task_rowid) && input$Task_rowid != "" && input$Task_rowid %in% colnames(currenttask$task$data())) {
+        currenttask$task$set_col_roles(currenttask$task$col_roles$name, roles = "feature")
+        currenttask$task$set_col_roles(input$Task_rowid, roles = "name")
+     } 
+    
+    currenttask$rowID <- input$Task_rowid
   }
   else if (is.null(data$traindata) && input$Task_backend == "imported training data" ) {
     shinyalert(title = "Task Creation", text = userhelp[["Task Creation"]], closeOnClickOutside = TRUE, animation = FALSE)
@@ -22,11 +54,42 @@ observe({
       selectInput(inputId = "Task_target", label = h5("Task Target"), choices = choices,
                   selected = choices[length(choices)])
     })
+    
+    choices_reduced <- c()
+    for (i in choices) {
+      if (!is.numeric(data$traindata[[i]]) && anyDuplicated(data$traindata[[i]]) == 0 && !any(is.na(data$traindata[[i]])) && !(currenttask$task$target_names %in% i)) {
+        choices_reduced <- c(choices_reduced, i)
+      }
+    }
+    
+    output$Task_make_rowid <- renderUI({
+      selectInput(
+        inputId = "Task_rowid",
+        label = tags$div(
+          style = "display: flex; align-items: center;",
+          h5("Row ID"),
+          tags$div(
+            title = "To remove the selected Row ID, please press the Backspace key.",
+            bs_icon("info-circle"),
+            style = "margin-left: 5px;"
+          )
+        ),
+        choices = c("No rowID" = "", choices_reduced),
+        selected = currenttask$task$col_roles$name
+      )
+    })
+    
     output$Task_make_task <- renderUI({
       div(style = "display:inline-block; width:100%; text-align: center;",
           actionButton(inputId = "Task_make", label = "Create Task", icon = icon("bookmark"))
       )
     })
+    
+    if(length(choices_reduced) > 0 && choices_reduced %in% colnames(currenttask$task$data())) {
+      shinyalert(title = "Potential Row ID Detected",
+                 text = "With the current settings, at least one variable with unique values will be used for model training. If you want to exclude this variable, please select it as Row ID.", 
+                 closeOnClickOutside = TRUE, animation = FALSE)
+    }
   }
 })
 
@@ -39,22 +102,35 @@ observe({
   toggle(id = "Task_target", condition = (input$Task_backend == "imported training data"))
   toggle(id = "Task_id", condition = (input$Task_backend == "imported training data"))
   toggle(id = "Task_make", condition = (input$Task_backend == "imported training data"))
+  toggle(id = "Task_rowid", condition = (input$Task_backend == "imported training data"))
 })
 
 # decide whether it is a classification or regression task
 observeEvent(input$Task_make, {
+
+  currenttask$rowID <- input$Task_rowid
+ 
   currenttask$target <- data$traindata[, input$Task_target]
 
   if (is.numeric(currenttask$target)) {
     currenttask$task <- TaskRegr$new(id = input$Task_id, backend = data$traindata, target = input$Task_target)
+    if (input$Task_rowid != "" && input$Task_rowid %in% colnames(currenttask$task$data())) {
+      currenttask$task$set_col_roles(currenttask$task$col_roles$name, roles = "feature")
+      currenttask$task$set_col_roles(input$Task_rowid, roles = "name")
+    } 
   }
   else if (is.factor(currenttask$target)) {
-    currenttask$task <- TaskClassif$new(id = input$Task_id, backend = data$traindata, target = input$Task_target)
+    currenttask$task <- TaskClassif$new(id = input$Task_id, backend = data$traindata, target = input$Task_target) 
+    if (input$Task_rowid != "" && input$Task_rowid %in% colnames(currenttask$task$data())) {
+      currenttask$task$set_col_roles(currenttask$task$col_roles$name, roles = "feature")
+      currenttask$task$set_col_roles(input$Task_rowid, roles = "name")
+    } 
   }
   else {
     shinyalert(title = "Target Selection",
                text = userhelp[["Task Creation Target"]], closeOnClickOutside = TRUE, animation = FALSE)
   }
+ 
 })
 
 # Task Summary
@@ -79,6 +155,7 @@ observe({
   if (!identical(currenttask$task$properties, character(0)) && currenttask$task$properties == "twoclass") {
     currenttask$positive <- currenttask$task$positive
   }
+
   # add positive label if twoclass
   currenttask$overview <- list(
     task_id <- currenttask$task$id,
@@ -87,6 +164,7 @@ observe({
     cols = currenttask$task$ncol,
     observations = currenttask$task$nrow,
     target = c(currenttask$task$target_names),
+    rowid = currenttask$rowID,
     features = currenttask$featTypes
   )
 })
@@ -120,10 +198,11 @@ printTaskOverviewUI = function() {
             addOverviewLineTask("Data: ", paste(currenttask$overview[[4]], "Variables with",
                                             currenttask$overview[[5]], "Observations", sep = " ")),
             addOverviewLineTask("Target: ", currenttask$overview[[6]]),
+            addOverviewLineTask("Rowid: ", currenttask$overview[[7]]), 
             if (!identical(currenttask$task$properties, character(0)) && currenttask$task$properties == "twoclass") {
             addOverviewLineTask("Positive Class: ", currenttask$positive)
-              },
-            addOverviewLineTask("Features: ", renderDataTable(expr = as.data.table(currenttask$overview[[7]]), rownames = FALSE,
+              }, 
+            addOverviewLineTask("Features: ", renderDataTable(expr = as.data.table(currenttask$overview[[8]]), rownames = FALSE, 
                                                           options = currenttask$tableOptions)
                             )
   )
@@ -260,7 +339,42 @@ observeEvent(input$action_visualize, {
     )
     return()
   }
+  
   task <- temp_task$select(cols = input$Features_Viz)
+  
+  
+  if (input$num_observations == "sample") {
+    if(is.na(input$sample_size)) {
+      output$warning <- renderUI({
+        p(style = "color: red;", "The number of observations cannot be empty.")
+      })
+      return()
+      
+    } else if(input$sample_size == 0) {
+      output$warning <- renderUI({
+        p(style = "color: red;", "The number of observations must be greater than 0.")
+      })
+      return()
+      
+    }else if(input$sample_size > currenttask$overview[[5]]) {
+      max_val <- currenttask$overview[[5]]
+      
+      output$warning <- renderUI({
+        p(style = "color: red;", sprintf("Value must be less than or equal to %d.", max_val)) 
+        })
+      return()
+      
+    } else {
+      output$warning <- renderUI({NULL})
+    }
+    n_observations <- input$sample_size
+    
+  } else {
+    output$warning <- renderUI({NULL})
+    n_observations <- input$num_observations
+  }
+  
+  task <- task$filter(rows = sample(task$row_ids, size = n_observations))
 
   output$show_viz <- reactive(TRUE)
   outputOptions(output, "show_viz", suspendWhenHidden = FALSE)
@@ -305,6 +419,54 @@ printTaskVisualizeUI <- function(){
                                 choices = originalTask$feature_names,
                                 multiple = TRUE,
                                 selected = originalTask$feature_names)))),
+    
+    tags$head(
+      tags$style(HTML("
+    #num_observations .radio:nth-child(2) > label > input[type='radio'] {
+      transform: translateY(9px);
+    }
+  "))
+    ),
+    
+    fluidRow(
+      column(4, h5("Size of the data:")),
+      column(8, 
+             radioButtons(
+               inputId = "num_observations",
+               label = NULL,
+               choiceNames = list(
+                 paste0("Entire dataset (", currenttask$overview[[5]], " observations)"),
+                 
+                 div(style = "display: flex; line-height:2.8;",
+                     div("Random subsample of"),
+                     div(style = "width: 70px; margin-left: 8px; margin-right: 8px;",
+                         numericInput(
+                           inputId = "sample_size",
+                           label = NULL,
+                           value = if (currenttask$overview[[5]] > 1000) 
+                             {1000}
+                           else if (currenttask$overview[[5]] <= 100) 
+                             {currenttask$overview[[5]]}
+                           else {100},
+                           min =if(currenttask$overview[[5]] >= 100) {100} else {currenttask$overview[[5]]},
+                           max = currenttask$overview[[5]],
+                           step = 1
+                         )
+                     ),
+                     div("observations")
+                 )
+               ),
+               
+               choiceValues = list(
+                 currenttask$overview[[5]],
+                 "sample"
+               ),
+               selected = currenttask$overview[[5]]
+             ),
+             uiOutput('warning')
+      )
+    ),
+    
     conditionalPanel(condition="input.action_visualize != 0 && output.show_viz == true", plotOutput(outputId = "plot_visualization") %>% withSpinner(color = "#38A8E8"))
   )
 }

--- a/inst/mlr3shiny/server/server_trainEvaluate.R
+++ b/inst/mlr3shiny/server/server_trainEvaluate.R
@@ -235,10 +235,22 @@ getScoreUi <- function(Wfstate){
 }
 
 getPredTable <- function(currentpred) {
-  if (!is.null(currentpred)) {
-    tabl <- DT::datatable(as.data.table(currentpred),
-                          options = list(scrollX = TRUE, searching = FALSE, bInfo = FALSE, lengthChange = FALSE))
-    return(tabl)
+  if (currenttask$rowID != ""){
+    if (!is.null(currentpred)) {
+      tabl <- as.data.table(currentpred)
+      
+      tabl$row_ids <- currenttask$task$data(rows = currentpred$row_ids, cols = currenttask$rowID)[[1]]
+      
+      tabl <- DT::datatable(tabl,
+                            options = list(scrollX = TRUE, searching = FALSE, bInfo = FALSE, lengthChange = FALSE))
+      return(tabl)
+    }
+  } else {
+    if (!is.null(currentpred)) {
+          tabl <- DT::datatable(as.data.table(currentpred),
+                                 options = list(scrollX = TRUE, searching = FALSE, bInfo = FALSE, lengthChange = FALSE))
+           return(tabl)
+         }
   }
 }
 

--- a/inst/mlr3shiny/ui.R
+++ b/inst/mlr3shiny/ui.R
@@ -5,6 +5,7 @@ for (i in seq_along(ui_files)) {
   source(ui_files[i], local = TRUE)
 }
 
+
 ui <- tagList(
   tags$head(
     tags$style(
@@ -38,7 +39,10 @@ ui <- tagList(
   ),
   navbarPage(
     theme =  bs_theme(version = 3, bootswatch = 'cerulean'),
-    title = a("mlr3shiny", href = "https://github.com/LamaTe/mlr3shiny", target = "_blank", style = "color: white;"),
+    title = div( style = "display: flex; flex-direction: column;justify-content: center; height: 100%;", 
+      a("mlr3shiny", href = "https://github.com/LamaTe/mlr3shiny", target = "_blank", style = "color: white;"),
+      div(paste("Version", get_version()), style = "color: white; font-size: 65%; margin-top: -3px;")
+    ),
     windowTitle = "mlr3shiny",
     id = "navbar",
     tabPanel("1. Data",

--- a/inst/mlr3shiny/ui/ui_predict.R
+++ b/inst/mlr3shiny/ui/ui_predict.R
@@ -26,6 +26,7 @@ tabpanel_predict <- fluidPage(
                fileInput(inputId = "Predict_data_csv", label = h5("Select a File"),
                          accept = c("text/csv", ".csv", "text/comma-separated-values,text/plain", "text*")),
                checkboxInput("Predict_data_header", "Header", TRUE),
+               checkboxInput("Predict_data_rowID", "Use rowID", FALSE), 
                selectInput(inputId = "Predict_data_sep", label = h5("Separator"),
                            choices = c(Comma = ",", Semicolon = ";", Tab = "\t", Space = " ", Vertical = "|")),
                selectInput(inputId = "Predict_data_quote", label = h5("Quote"),

--- a/inst/mlr3shiny/ui/ui_task.R
+++ b/inst/mlr3shiny/ui/ui_task.R
@@ -12,6 +12,7 @@ tabpanel_Task <- fluidPage(
                                   selected = "iris", multiple = FALSE),
                       uiOutput(outputId = "Task_make_id"),
                       uiOutput(outputId = "Task_make_target"),
+                      uiOutput(outputId = "Task_make_rowid"), 
                       uiOutput(outputId = "Task_make_task")
                ),
                column(8,


### PR DESCRIPTION
- Adjusted the available Predict Types for regression tasks 
- Fixed a bug that caused Shiny to crash after switching the SVM kernel 
- Added a subset option to the autoplot in Task 
- Added Shiny version to the title 
- Added error modal when the GraphLearner cannot be plotted 
- Improved the error modal shown when predicting without a trained learner 
- Added the option to select a row-ID 
- Changed the default label of a learner 
- Fixed outdated code that caused a crash in Explain